### PR TITLE
Configure disqus shortname for staging and production env.

### DIFF
--- a/src/js/components/blog/constants.js
+++ b/src/js/components/blog/constants.js
@@ -1,1 +1,1 @@
-export const DISQUS_SHORT_NAME = 'teencodeafrica';
+export const DISQUS_SHORT_NAME = process.env.NODE_ENV === 'production' ? 'teencodeafrica' : 'teencodeafrica-staging';


### PR DESCRIPTION
### What doe's this PR do ?
It configures different Disqus comment threads accounts for staging and production environment
### How to test this ?
Create comments on the review app created by this PR (or on the staging branch if this is merged into staging) user and confirm that those comments do not reflect on the production app. 
Also, comments made on the production app should not reflect on the staging app.