### PR TITLE
Configure disqus shortname for staging and production env.

### DIFF
--- a/src/js/components/blog/BlogArticle.js
+++ b/src/js/components/blog/BlogArticle.js
@@ -5,7 +5,6 @@ import { Link } from 'react-router';
 import { getFeaturedBlogs, getBlogArticle } from '../../actions/blogActions';
 import SocialLinks from './SocialLinks';
 import ArticleThread from './ArticleThread';
-import { DISQUS_SHORT_NAME } from './constants';
 import Loader from '../common/Loader';
 import NotFoundPage from '../not_found/notFound';
 import { parseBlogTitle } from '../../utils/parseBlogTitle';
@@ -137,11 +136,18 @@ class BlogArticle extends Component {
                 <ArticleThread
                   articleId={this.props.params.id}
                   articleTitle={article.title}
-                  shortName={DISQUS_SHORT_NAME}
+                  shortName={process.env.DISQUS_SHORT_NAME}
                 />
               </div>
             </div>
           </div>
+        </div>
+        <div className="article-thread">
+          <ArticleThread
+            articleId={this.props.params.id}
+            articleTitle={article.title}
+            shortName={process.env.DISQUS_SHORT_NAME}
+          />
         </div>
       </div>
     );

--- a/src/js/components/blog/constants.js
+++ b/src/js/components/blog/constants.js
@@ -1,1 +1,0 @@
-export const DISQUS_SHORT_NAME = 'teencodeafrica';

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -8,6 +8,12 @@ const nodeModulesPath = path.resolve(__dirname, 'node_modules');
 const buildPath = path.resolve(__dirname, 'dist');
 const entryPath = path.resolve(__dirname, 'src', 'js', 'index.js');
 
+const GLOBALS = {
+  'teencode.feature': featureFlags,
+  'process.env.FB_APPID': JSON.stringify(process.env.FB_APPID),
+  'process.env.DISQUS_SHORT_NAME': JSON.stringify(process.env.DISQUS_APP_NAME)
+};
+
 export default {
   debug: true,
   devtool: 'cheap-module-eval-source-map',
@@ -36,10 +42,7 @@ export default {
       Tether: 'tether',
       'window.Tether': 'tether'
     }),
-    new webpack.DefinePlugin({
-      'teencode.feature': featureFlags,
-      'process.env.FB_APPID': JSON.stringify(process.env.FB_APPID)
-    })
+    new webpack.DefinePlugin(GLOBALS)
   ],
   module: {
     loaders: [

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -9,7 +9,8 @@ const entryPath = path.resolve(__dirname, 'src', 'js', 'index.js');
 
 const GLOBALS = {
   'process.env.NODE_ENV': JSON.stringify('production'),
-  'process.env.FB_APPID': JSON.stringify(process.env.FB_APPID)
+  'process.env.FB_APPID': JSON.stringify(process.env.FB_APPID),
+  'process.env.DISQUS_SHORT_NAME': JSON.stringify(process.env.DISQUS_APP_NAME)
 };
 
 export default {


### PR DESCRIPTION
### What doe's this PR do ?
It configures different Disqus comment threads accounts for staging and production environment

### How to test this ?
Create comments on the review app created by this PR (or on the staging branch if this is merged into staging) user and confirm that those comments do not reflect on the production app. 
Also, comments made on the production app should not reflect on the staging app.